### PR TITLE
Added new formula: nexus

### DIFF
--- a/formulas/nexus
+++ b/formulas/nexus
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# more about configuring nexus
+# http://books.sonatype.com/nexus-book/2.10/reference/npm-configuring.html
+# 
+# original cudos to Marcello de Sales:
+# https://registry.hub.docker.com/u/marcellodesales/nexus-npm-registry/
+
+source "${BASH_SOURCE%/*}/../common"
+
+force_stop nexus
+
+run --detach \
+    --publish 80:8081 \
+    --name nexus \
+    -d \
+    -v /app/npm-volume/:/opt/sonatype-work \
+    marcellodesales/nexus-npm-registry


### PR DESCRIPTION
Use as proxy/cache for http://registry.npmjs.org !

See https://registry.hub.docker.com/u/marcellodesales/nexus-npm-registry
and http://books.sonatype.com/nexus-book/2.10/reference/npm-configuring.html

Must create a npm proxy repository, and a npm-all group in nexus. Then use npm install grunt --registry=$DOCKER_IP/nexus
or
adapt  ~/.npmrc 
