### PR TITLE
Add possibility to use custom formulas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ For a list of supported programs run `dock -l` or check out this repository's
 Feel free to send a pull request for any awesome Docker containers that are
 still missing!
 
+Dock will look for custom formulas in a .dock-formulas directory relative to
+where it was started. So if you need a formula for a custom docker image that
+you don't want to make public through docker hub, you can put your formulas there.
+
 ## Credits
 dock was written by Ben Ripkens ([@BenRipkens](https://twitter.com/BenRipkens)).
 

--- a/dock
+++ b/dock
@@ -6,6 +6,7 @@
 
 remote_repo=https://github.com/bripkens/dock.git
 local_repo=$HOME/.dock-formulas
+working_dir=`pwd`
 
 
 version() {
@@ -68,13 +69,20 @@ init() {
 list() {
   init --silently
 
-  echo ":: Available Formulas"
-  for path in $(ls "$local_repo"/formulas | sort -f); do
+  echo ":: Build-in Formulas"
+  listFormulas "$local_repo"/formulas
+  if [ -d "$working_dir"/.dock-formulas ]; then
+    echo ":: Project Formulas"
+    listFormulas "$working_dir"/.dock-formulas
+  fi
+}
+
+listFormulas() {
+  for path in $(ls "$1" | sort -f); do
     filename=$(basename $path)
     echo "${filename%.*}"
   done
 }
-
 
 redock() {
   if hash boot2docker 2>/dev/null; then
@@ -126,17 +134,23 @@ start() {
   redock
   check_docker_usage_possible
 
-  formula="$local_repo/formulas/$1"
+  project_formula="$working_dir/.dock-formulas/$1"
+  builtin_formula="$local_repo/formulas/$1"
 
-  if [ -e "$formula" ]; then
-    echo
-    echo "Starting $1 (using $formula)"
-    bash $formula
+  if [ -e "$project_formula" ]; then
+    startFormula $1 $project_formula
+  elif [ -e "$builtin_formula" ]; then
+    startFormula $1 $builtin_formula
   else
     unknown_formula $1
   fi
 }
 
+startFormula() {
+  echo
+  echo "Starting $1 (using $2)"
+  bash $2
+}
 
 stop_and_remove() {
   check_docker_usage_possible


### PR DESCRIPTION
Add some logic to look for custom formulas in a folder called .dock-formulas. This way users can put their custom dock formulas for custom docker images they don't want to make public inside their projects. Project formulas have priority over built-in formulas.
