### PR TITLE
Make redock available for end users

### DIFF
--- a/dock
+++ b/dock
@@ -29,6 +29,7 @@ Example:
 
 Options:
     -l, --list               List available formulas
+    -r, --redock             Set docker environment variables
     -c, --cat [formula]      Display formula details
     -u, --upgrade            Upgrade list of available formulas
     -d, --rm                 Stop and remove all containers
@@ -180,6 +181,10 @@ while [ $# -gt 0 ]; do
       ;;
     -d | --rm )
       stop_and_remove
+      exit
+      ;;
+    -r | --redock)
+      redock
       exit
       ;;
     * ) # default case


### PR DESCRIPTION
The redock command can be useful outside of dock. Would be good to make it public.
