### PR TITLE
seperated couchdb and couchdb-ssl

### DIFF
--- a/formulas/couchdb
+++ b/formulas/couchdb
@@ -5,12 +5,6 @@ source "${BASH_SOURCE%/*}/../common"
 force_stop dock-couchdb
 
 run --detach \
-    --publish 6984:6984 \
+    --publish 5984:5984 \
     --name dock-couchdb \
-    klaemo/couchdb-ssl:latest
-
-echo 'Note:           CouchDB is only accepting https connections on port 6984.'
-echo '                Make sure to accept self-signed and unverified, i.e.'
-echo '                insecure, connections.'
-echo '                Example: curl -k https://$DOCKER_IP:6984'
-
+    klaemo/couchdb:latest

--- a/formulas/couchdb-ssl
+++ b/formulas/couchdb-ssl
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+source "${BASH_SOURCE%/*}/../common"
+
+force_stop dock-couchdb-ssl
+
+run --detach \
+    --publish 6984:6984 \
+    --name dock-couchdb-ssl \
+    klaemo/couchdb-ssl:latest
+
+echo 'Note:           CouchDB is only accepting https connections on port 6984.'
+echo '                Make sure to accept self-signed and unverified, i.e.' 
+echo '                insecure, connections.' 
+echo '                Example: curl -k https://$DOCKER_IP:6984'


### PR DESCRIPTION
I've separated the encrypted and plaintext couchdb formulae, sorry about that! :+1: 