### PR TITLE
Use the new official neo4j image

### DIFF
--- a/formulas/neo4j
+++ b/formulas/neo4j
@@ -7,4 +7,4 @@ force_stop dock-neo4j
 run --detach \
     --publish 7474:7474 \
     --name dock-neo4j \
-    tpires/neo4j
+    neo4j/neo4j


### PR DESCRIPTION
The neo4j team recently published an official neo4j image (see http://neo4j.com/blog/neo4j-docker-image-now-in-beta/). Dock should use the official image instead of the user image by tripes.