### PR TITLE
Use the official jfrog image for artifactory oss

### DIFF
--- a/formulas/artifactory
+++ b/formulas/artifactory
@@ -5,6 +5,6 @@ source "${BASH_SOURCE%/*}/../common"
 force_stop dock-artifactory
 
 run --detach \
-    --publish 8473:8080 \
+    --publish 8473:8081 \
     --name dock-artifactory \
-    mattgruter/artifactory
+    jfrog-docker-registry.bintray.io/jfrog/artifactory-oss


### PR DESCRIPTION
jfrog recently published an offical artifactory docker image. This PR changes the artifactory forumla to use the official image. More information about the image can be found at http://www.jfrog.com/confluence/display/RTF/Running+with+Docker