### PR TITLE
add formulas for PHP 5 and 7

### DIFF
--- a/formulas/php5-fpm
+++ b/formulas/php5-fpm
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source "${BASH_SOURCE%/*}/../common"
+
+force_stop php5-fpm
+
+run --detach \
+    --publish 9000 \
+    --name php5-fpm \
+    --volume $(pwd):/var/www/html \
+    php:5-fpm
+
+echo "Mounted $(pwd) into /var/www/html"

--- a/formulas/php7-fpm
+++ b/formulas/php7-fpm
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source "${BASH_SOURCE%/*}/../common"
+
+force_stop php7-fpm
+
+run --detach \
+    --publish 9000 \
+    --name php7-fpm \
+    --volume $(pwd):/var/www/html \
+    php:7-fpm
+
+echo "Mounted $(pwd) into /var/www/html"


### PR DESCRIPTION
This commit adds formulas for PHP-FPM 5 and 7. Dock will pull from the official PHP repository at https://hub.docker.com/_/php/

The formulas will mount the current working directory into `/var/www/html`, so any files you place here can be accessed via FCGI. To interact with PHP-FPM, either link up a webserver or connect directly via `cgi-fcgi`, e.g.

    sudo apt-get install libfcgi0ldbl

and then you do

    SCRIPT_NAME=/var/www/html/helloworld.php \
    SCRIPT_FILENAME=/var/www/html/helloworld.php \
    REQUEST_METHOD=GET \
    cgi-fcgi -bind -connect 127.0.0.1:9000

Note that your port may vary and you need to have any called files in your working directory.

Installing PHP-FPM will also install PHP CLI into the container. This means you can also use PHP's built-in webserver. To do so, grab the IP of the container:

    docker exec php7-fpm hostname -I
    172.17.0.20 

To run and expose the webserver listening on that IP, do: 

    docker exec php7-fpm php -S 172.17.0.20:8080 -t /var/www/html

You can then open your browser and point it to that IP and port and it will serve whatever files are in the document root. This is a different SAPI than FPM though.