### PR TITLE
add formulas for php5 and php7 with apache

### DIFF
--- a/formulas/php5-apache
+++ b/formulas/php5-apache
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source "${BASH_SOURCE%/*}/../common"
+
+force_stop dock-php5-apache
+
+run --detach \
+    --publish 80 \
+    --name dock-php5-apache \
+    --volume $(pwd):/var/www/html \
+    php:5-apache
+
+echo "Mounted $(pwd) into /var/www/html"

--- a/formulas/php7-apache
+++ b/formulas/php7-apache
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source "${BASH_SOURCE%/*}/../common"
+
+force_stop dock-php7-apache
+
+run --detach \
+    --publish 80 \
+    --name dock-php7-apache \
+    --volume $(pwd):/var/www/html \
+    php:7-apache
+
+echo "Mounted $(pwd) into /var/www/html"


### PR DESCRIPTION
adds formulas to create a docker container including an apache. This uses the official PHP docker repo images. The current working dir will be mounted into the webroot of the container, so anything you put there can be served by apache.