### PR TITLE
fix invalid name in force_stop call

### DIFF
--- a/formulas/php5-fpm
+++ b/formulas/php5-fpm
@@ -2,7 +2,7 @@
 
 source "${BASH_SOURCE%/*}/../common"
 
-force_stop php5-fpm
+force_stop dock-php5-fpm
 
 run --detach \
     --publish 9000 \

--- a/formulas/php7-fpm
+++ b/formulas/php7-fpm
@@ -2,7 +2,7 @@
 
 source "${BASH_SOURCE%/*}/../common"
 
-force_stop php7-fpm
+force_stop dock-php7-fpm
 
 run --detach \
     --publish 9000 \


### PR DESCRIPTION
aligns the container names in the `force_stop` call to the changes made by @bripkens in 505a42dcbad77b657d98d66fe549c769ec59e9f3