### PR TITLE
add formula for latest version of Wordpress

### DIFF
--- a/formulas/wordpress
+++ b/formulas/wordpress
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source "${BASH_SOURCE%/*}/../common"
+
+force_stop dock-wordpress
+
+run --detach \
+    --publish 80 \
+    --name dock-wordpress \
+    --link dock-mysql:mysql \
+    wordpress:latest
+

--- a/formulas/wordpress
+++ b/formulas/wordpress
@@ -10,3 +10,6 @@ run --detach \
     --link dock-mysql:mysql \
     wordpress:latest
 
+echo "General Database access: same as dock-wordpress"
+echo "Wordpress Database name: wordpress"
+echo "Wordpress Database user: root"


### PR DESCRIPTION
This adds the formula for Wordpress:latest. This includes Apache and PHP and links dock-mysql. When the container is running, open your browser, go to the echo'ed URL and you are ready to setup a vanilla wordpress.