### PR TITLE
Add completions for fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ curl https://raw.githubusercontent.com/bripkens/dock/master/dock -so ~/bin/dock 
      echo "dock installation successful. Try running 'dock'"
 ```
 
+## Command completion
+
+To add command completion to [fish](https://fishshell.com) copy the `dock.fish` file to `~/.config/fish/completions`.
+
 ## Supported programs
 For a list of supported programs run `dock -l` or check out this repository's
 [formulas/](https://github.com/bripkens/dock/tree/master/formulas) directory.

--- a/dock.fish
+++ b/dock.fish
@@ -1,0 +1,11 @@
+function __all_dock_formulars
+  dock -l | tail -n +2 | tr '\n' ' '
+end
+
+complete -c dock -a (__all_dock_formulars)
+complete -c dock -s l -l list -d 'List available formulas'
+complete -c dock -s c -l cat -a (__all_dock_formulars) -d 'Display formula details'
+complete -c dock -s u -l upgrade -d 'Upgrade list of available formulas'
+complete -c dock -s d -l rm -d 'Stop and remove all containers'
+complete -c dock -s h -l help -d 'Display help text'
+complete -c dock -s v -l version -d 'Display current script version'


### PR DESCRIPTION
Add completions for fish. This file has to be installed to `~/.config/fish/completions`. I currently don't know whether this can be done automatically during the homebrew installation.