### PR TITLE
Implement dock formula of 'vault' in dev mode

### DIFF
--- a/formulas/vault
+++ b/formulas/vault
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source "${BASH_SOURCE%/*}/../common"
+
+force_stop dock-vault
+
+token="00f0c15f-cb5d-ef15-a813-58e32927054c"
+
+docker run -d \
+      -p 8200:8200 \
+      --name dock-vault sjourdan/vault \
+      server -dev-listen-address=0.0.0.0:8200 -dev-root-token-id=$token -dev
+
+echo "Root token of vault = $token"


### PR DESCRIPTION
While experimenting around with [vault](https://www.vaultproject.io/) I thought it might be interesting to implement a **dock** formula which also provides a root token to play around with. This formula provides a docker container running a vault server in development mode inside.
